### PR TITLE
add temporary hbg3 variant: hbg5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If they have been updated, they get
 * downloaded, 
 * quality checked via mecatran's [GTFSVTOR feedvalidator](https://gtfsvtor.mecatran.com/utw-test/web/pub/gtfsvtor)
 * optionally enhanced with shapes using OSM data and the [pfaedle tool](https://github.com/ad-freiburg/pfaedle)
-* optionally transformed with the [OneBusAway GTFS transformer tool](http://developer.onebusaway.org/modules/onebusaway-gtfs-modules/1.3.4-SNAPSHOT/onebusaway-gtfs-transformer-cli.html) (fed with a feed specific rule file)
+* optionally transformed with the [OneBusAway GTFS transformer tool](http://developer.onebusaway.org/modules/onebusaway-gtfs-modules/1.3.4-SNAPSHOT/onebusaway-gtfs-transformer-cli.html) (fed with a feed specific [rule file](https://github.com/OneBusAway/onebusaway-gtfs-modules/blob/15525f709ab75e50d79cb5c1b5fb23154f85d65e/src/site/apt/onebusaway-gtfs-transformer-cli.apt.vm#L52-L486))
 * and optionally merged into larger aggregated GTFS feeds or filtered to a regional subset
 
 ### Updating and preparing OSM data

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ osm: data/osm/bw-buffered.osm data/osm/bw-buffered.osm.pbf
 
 # To add a new merged feed, add it's shortname here and define the variable definitions and targets as for HBG below
 MERGED = hbg hbg2 hbg3 ulm
-MERGED_WITH_FLEX = hbg3
+MERGED_WITH_FLEX = hbg3 hbg5
 # To add a new filtered feed, add it's shortname below and add a DELFI.<shortname>.rule filter rule in config/gtfs-rules.
 # NOTE: currently shape enhancement only is done using bw-buffered.osm
 FILTERED = BW
@@ -99,6 +99,14 @@ data/gtfs/hbg4.merged.gtfs.zip: $(HBG4_FILES)
 	$(MERGE) $(^F:%=$(TOOL_DATA)/gtfs/%) $(TOOL_DATA)/gtfs/$(@F)
 	cp config/hbg.feed_info.txt /tmp/feed_info.txt
 	zip -u -j $@ /tmp/feed_info.txt
+
+# temporary variant of hbg3, because we don't want to break production, which uses hbg3
+data/gtfs/hbg5.merged.with_flex.gtfs: data/gtfs/hbg3.merged.gtfs.zip
+	$(info unzipping $* GTFS feed)
+	rm -rf $@
+	unzip -d $@ $<
+	$(info patching GTFS-Flex data into the GTFS feed (using derhuerst/generate-herrenberg-gtfs-flex#6))
+	docker run -i --rm -v $(HOST_MOUNT)/data/gtfs/$(@F):/gtfs derhuerst/generate-herrenberg-gtfs-flex:duplicate-stop-times
 
 data/gtfs/%.merged.with_flex.gtfs: data/gtfs/%.merged.gtfs.zip
 	$(info unzipping $* GTFS feed)


### PR DESCRIPTION
`hbg5` is like `hbg3`, but it includes the changes in https://github.com/derhuerst/generate-herrenberg-gtfs-flex/pull/6. Once know them to work and have merged them, I will remove `hbg5` and adapt `hbg3` accordingly.