### PR TITLE
hbg6: use renamed derhuerst/generate-gtfs-flex Docker image

### DIFF
--- a/makefile
+++ b/makefile
@@ -103,7 +103,8 @@ data/gtfs/%.merged.with_flex.gtfs: data/gtfs/%.merged.gtfs.zip
 	rm -rf $@
 	unzip -d $@ $<
 	$(info patching GTFS-Flex data into the GTFS feed)
-	docker run -i --rm -v $(HOST_MOUNT)/data/gtfs/$(@F):/gtfs derhuerst/generate-herrenberg-gtfs-flex
+	# todo: pick flex rules file based on GTFS feed
+	docker run -i --rm -v $(HOST_MOUNT)/data/gtfs/$(@F):/gtfs derhuerst/generate-gtfs-flex:4 stadtnavi-herrenberg-flex-rules.js
 
 data/gtfs/%.merged.with_flex.gtfs.zip: data/gtfs/%.merged.with_flex.gtfs
 	rm -f $@


### PR DESCRIPTION
As part of https://github.com/derhuerst/generate-gtfs-flex/pull/17, `derhuerst/generate-herrenberg-gtfs-flex` ~~will be~~ has been renamed to `derhuerst/generate-gtfs-flex`. To make sure that future major/backwards-incompatible releases don't break `gtfs-hub`, I have used the `4` tag instead of `latest`.

Also, specifying the flex rules file is now mandatory, it does not default to `herrenberg-flex-rules.js` anymore, so we explicitly provide it here.