### PR TITLE
fix: remove duplicate route x27

### DIFF
--- a/config/gtfs-rules/bwgesamt.extract.rule
+++ b/config/gtfs-rules/bwgesamt.extract.rule
@@ -1,4 +1,6 @@
 {"op":"retain", "match":{"file": "routes.txt", "route_id": "m/rab-.*|vpe-.*|tub-.*|cw-.*|din-.*|ddb-.*|rbs-.*/"}}
+# X27 is provided via VVS and tub, we retain VVS, as VVS (hopefully) provides gtfs-rt
+{"op":"remove", "match":{"file": "routes.txt", "route_id": "m/tub-15-X27-1/"}}
 {"op":"remove", "match":{"file": "routes.txt", "route_id": "m/ddb-92-T.*/"}}
 # workaround for https://github.com/mfdz/GTFS-Issues/issues/108 
 {"op":"update", "match":{"file":"stops.txt", "stop_id":"de:08118:7503"}, "update":{"stop_id":"de:08118:7503:tmp:tmp"}}


### PR DESCRIPTION
This PR fixes #45 by removing X27 from the bwextract.